### PR TITLE
Padhye

### DIFF
--- a/projects/batfish/src/org/batfish/grammar/cisco/CiscoLexer.g4
+++ b/projects/batfish/src/org/batfish/grammar/cisco/CiscoLexer.g4
@@ -1832,6 +1832,11 @@ EGRESS
    'egress'
 ;
 
+EGRESS_INTERFACE_SELECTION
+:
+   'egress-interface-selection'  
+;
+
 EIGRP
 :
    'eigrp'

--- a/projects/batfish/src/org/batfish/grammar/cisco/CiscoParser.g4
+++ b/projects/batfish/src/org/batfish/grammar/cisco/CiscoParser.g4
@@ -488,9 +488,8 @@ mgmt_egress_iface_stanza
          | APPLICATION SYSLOG
          | APPLICATION SSH
       ) NEWLINE
-   )+ 
+   )+ EXIT NEWLINE
 ;
-
 
 mgmt_ip_access_group
 :

--- a/projects/batfish/src/org/batfish/grammar/cisco/CiscoParser.g4
+++ b/projects/batfish/src/org/batfish/grammar/cisco/CiscoParser.g4
@@ -476,6 +476,22 @@ l2vpn_stanza
    L2VPN NEWLINE xconnect_stanza*
 ;
 
+mgmt_egress_iface_stanza
+:
+   MANAGEMENT EGRESS_INTERFACE_SELECTION NEWLINE
+   (
+      (
+         APPLICATION HTTP
+         | APPLICATION SNMP
+         | APPLICATION RADIUS
+         | APPLICATION TACACS
+         | APPLICATION SYSLOG
+         | APPLICATION SSH
+      ) NEWLINE
+   )+ 
+;
+
+
 mgmt_ip_access_group
 :
    IP ACCESS_GROUP name = variable
@@ -1266,6 +1282,7 @@ stanza
    | ipv6_router_ospf_stanza
    | ipx_sap_access_list_stanza
    | l2vpn_stanza
+   | mgmt_egress_iface_stanza
    | multicast_routing_stanza
    | mpls_ldp_stanza
    | mpls_traffic_eng_stanza


### PR DESCRIPTION
fixed parser to parse the following:

change 1:

>>>> no class-map

this one was easy: just added to ignore.

change 2:

class-map match-any BEST_EFFORT
  >>> match ip access-group dscp_0_non_ecn set-color yellow
  match ip access-group dscp_0

For this, I updated the rule for class map match, and added a color-setter matcher, and defined red, yellow and green as tokens,
