### PR TITLE
Interface MTU parsed and added to config. Fixed IPV6 deserialization …

### DIFF
--- a/projects/batfish-common-protocol/src/org/batfish/datamodel/Interface.java
+++ b/projects/batfish-common-protocol/src/org/batfish/datamodel/Interface.java
@@ -41,6 +41,8 @@ public final class Interface extends ComparableStructure<String> {
 
    private static final String ISIS_L2_INTERFACE_MODE_VAR = "isisL2InterfaceMode";
 
+   private static final String MTU = "mtu";
+   
    private static final String NATIVE_VLAN_VAR = "nativeVlan";
 
    private static final String OSPF_AREA_VAR = "ospfArea";
@@ -265,6 +267,8 @@ public final class Interface extends ComparableStructure<String> {
    private IsisInterfaceMode _isisL1InterfaceMode;
 
    private IsisInterfaceMode _isisL2InterfaceMode;
+   
+   private int _mtu;
 
    private int _nativeVlan;
 
@@ -374,6 +378,12 @@ public final class Interface extends ComparableStructure<String> {
       return _isisL2InterfaceMode;
    }
 
+   @JsonProperty(MTU)
+   public int getMtu()
+   {
+      return _mtu;
+   }
+   
    @JsonProperty(NATIVE_VLAN_VAR)
    public int getNativeVlan() {
       return _nativeVlan;
@@ -518,6 +528,12 @@ public final class Interface extends ComparableStructure<String> {
       _isisL2InterfaceMode = mode;
    }
 
+   @JsonProperty(MTU)
+   public void setMTU(int mtu)
+   {
+      _mtu = mtu;
+   }
+   
    @JsonProperty(NATIVE_VLAN_VAR)
    public void setNativeVlan(int vlan) {
       _nativeVlan = vlan;

--- a/projects/batfish-common-protocol/src/org/batfish/datamodel/IpProtocol.java
+++ b/projects/batfish-common-protocol/src/org/batfish/datamodel/IpProtocol.java
@@ -66,7 +66,7 @@ public enum IpProtocol {
    IPIP(94),
    IPLT(129),
    IPPC(67),
-   IPv6(41),
+   IPV6(41),
    IPv6_Frag(44),
    IPv6_ICMP(58),
    IPv6_NoNxt(59),

--- a/projects/batfish/src/org/batfish/grammar/cisco/Cisco_interface.g4
+++ b/projects/batfish/src/org/batfish/grammar/cisco/Cisco_interface.g4
@@ -57,6 +57,7 @@ if_stanza
    | isis_network_if_stanza
    | isis_passive_if_stanza
    | isis_tag_if_stanza
+   | mtu_if_stanza
    | no_ip_address_if_stanza
    | null_if_stanza
    | shutdown_if_stanza
@@ -216,6 +217,11 @@ isis_tag_if_stanza
    ISIS TAG tag = DEC NEWLINE
 ;
 
+mtu_if_stanza
+:
+   MTU mtu_size = DEC NEWLINE
+;
+   
 no_ip_address_if_stanza
 :
    NO IP ADDRESS NEWLINE

--- a/projects/batfish/src/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
+++ b/projects/batfish/src/org/batfish/grammar/flatjuniper/ConfigurationBuilder.java
@@ -1273,7 +1273,7 @@ public class ConfigurationBuilder extends FlatJuniperParserBaseListener {
          return IpProtocol.IPINIP;
       }
       else if (ctx.IPV6() != null) {
-         return IpProtocol.IPv6;
+         return IpProtocol.IPV6;
       }
       else if (ctx.OSPF() != null) {
          return IpProtocol.OSPF;

--- a/projects/batfish/src/org/batfish/representation/cisco/CiscoVendorConfiguration.java
+++ b/projects/batfish/src/org/batfish/representation/cisco/CiscoVendorConfiguration.java
@@ -1156,6 +1156,7 @@ public final class CiscoVendorConfiguration extends CiscoConfiguration {
       newIface.setDescription(iface.getDescription());
       newIface.setActive(iface.getActive());
       newIface.setBandwidth(iface.getBandwidth());
+      newIface.setMTU(iface.getMtu());
       if (iface.getPrefix() != null) {
          newIface.setPrefix(iface.getPrefix());
          newIface.getAllPrefixes().add(iface.getPrefix());
@@ -2380,6 +2381,8 @@ public final class CiscoVendorConfiguration extends CiscoConfiguration {
 
       processFailoverSettings();
 
+      // convert Interface MTUs
+     
       // convert as path access lists to vendor independent format
       for (IpAsPathAccessList pathList : _asPathAccessLists.values()) {
          AsPathAccessList apList = toAsPathAccessList(pathList);

--- a/projects/batfish/src/org/batfish/representation/cisco/Interface.java
+++ b/projects/batfish/src/org/batfish/representation/cisco/Interface.java
@@ -31,7 +31,7 @@ public class Interface extends ComparableStructure<String> {
    private static final long serialVersionUID = 1L;
 
    private static final double TEN_GIGABIT_ETHERNET_BANDWIDTH = 10E9;
-
+   
    public static double getDefaultBandwidth(String name) {
       Double bandwidth = null;
       if (name.startsWith("FastEthernet")) {
@@ -58,6 +58,13 @@ public class Interface extends ComparableStructure<String> {
       return bandwidth;
    }
 
+   private static final int DEFAULT_INTERFACE_MTU = 1500;
+   
+   public static int getDefaultMtu()
+   {
+      return DEFAULT_INTERFACE_MTU;
+   }
+   
    private int _accessVlan;
 
    private boolean _active;
@@ -73,6 +80,8 @@ public class Interface extends ComparableStructure<String> {
    private Integer _isisCost;
 
    private IsisInterfaceMode _isisInterfaceMode;
+   
+   private int _mtu;
 
    private int _nativeVlan;
 
@@ -153,6 +162,11 @@ public class Interface extends ComparableStructure<String> {
 
    public IsisInterfaceMode getIsisInterfaceMode() {
       return _isisInterfaceMode;
+   }
+   
+   public int getMtu()
+   {
+      return _mtu;
    }
 
    public int getNativeVlan() {
@@ -235,6 +249,11 @@ public class Interface extends ComparableStructure<String> {
       _isisInterfaceMode = mode;
    }
 
+   public void setMtu(int mtu)
+   {
+      _mtu = mtu;
+   }
+   
    public void setNativeVlan(int vlan) {
       _nativeVlan = vlan;
    }


### PR DESCRIPTION
Please pull to master. 

Interface MTU parsing is simple: I added support to parse interface config like "mtu 9100", and carried it through to vendor independent configuration object. 

The second issue (changing IPv6 to IPV6) is a bit convoluted. There are two problems. The first one is this:

- The jakcson desrealizer does not work with "IPv6". It expects an upper case string. You may want to fix it in some other way, since there are other mixed-case enum definitions. Take a look.

There is one other issue will I will send you email about. 

